### PR TITLE
Added damage on bounce

### DIFF
--- a/WhenPushComesToShove/Assets/1-Scenes/TestScenes/EnemyTest.unity
+++ b/WhenPushComesToShove/Assets/1-Scenes/TestScenes/EnemyTest.unity
@@ -209,6 +209,39 @@ MonoBehaviour:
   - {fileID: 1347505020}
   playerPrefab: {fileID: 6273220948599445249, guid: 06a8200273c476048a5a1372f2ec0988, type: 3}
   initOnStart: 0
+  lockPlayerSpawn: 0
+--- !u!1 &170120472 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 999011918721937567, guid: 6f6bae884535d794987296190dee6baa, type: 3}
+  m_PrefabInstance: {fileID: 999011919178601312}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &170120473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 170120472}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e4872b3bbe5c44c8d905b01671f21e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: {fileID: 1488986576}
+  vs: {fileID: 170120477}
+  sourcesToIgnore:
+  - Move
+--- !u!114 &170120477 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 999011918721939299, guid: 6f6bae884535d794987296190dee6baa, type: 3}
+  m_PrefabInstance: {fileID: 999011919178601312}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 170120472}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dfb45aa8271de64c9aad4b74693fc91, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &276471232
 GameObject:
   m_ObjectHideFlags: 0
@@ -334,6 +367,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   elasticity: 0.25
+  damageMultiplier: 0.6
 --- !u!1 &324201405
 GameObject:
   m_ObjectHideFlags: 0
@@ -521,6 +555,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   elasticity: 0.75
+  damageMultiplier: 0.6
 --- !u!1 &575614096 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1883854870026651927, guid: afb30945538a837429b920c372b3ff52, type: 3}
@@ -973,6 +1008,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   elasticity: 1
+  damageMultiplier: 0.6
 --- !u!1 &1347505019
 GameObject:
   m_ObjectHideFlags: 0
@@ -1129,6 +1165,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   elasticity: 0.5
+  damageMultiplier: 0.6
+--- !u!114 &1488986576 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 999011920060830536, guid: 6f6bae884535d794987296190dee6baa, type: 3}
+  m_PrefabInstance: {fileID: 999011919178601312}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5eea28615ab24824fb7a301cb8be3b87, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1750270791
 GameObject:
   m_ObjectHideFlags: 0
@@ -1401,6 +1449,10 @@ PrefabInstance:
     - target: {fileID: 999011918721937567, guid: 6f6bae884535d794987296190dee6baa, type: 3}
       propertyPath: m_Name
       value: Slime
+      objectReference: {fileID: 0}
+    - target: {fileID: 999011918721937567, guid: 6f6bae884535d794987296190dee6baa, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 999011918721939297, guid: 6f6bae884535d794987296190dee6baa, type: 3}
       propertyPath: m_RootOrder

--- a/WhenPushComesToShove/Assets/1-Scenes/TestScenes/KnockbackTest.unity
+++ b/WhenPushComesToShove/Assets/1-Scenes/TestScenes/KnockbackTest.unity
@@ -310,6 +310,7 @@ MonoBehaviour:
   - {fileID: 1347505020}
   playerPrefab: {fileID: 6273220948599445249, guid: 06a8200273c476048a5a1372f2ec0988, type: 3}
   initOnStart: 0
+  lockPlayerSpawn: 0
 --- !u!1 &276471232
 GameObject:
   m_ObjectHideFlags: 0
@@ -434,7 +435,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8868fc24decd05e40b88174ab164b657, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  elasticity: 0.25
+  elasticity: 1
+  damageMultiplier: 0.6
 --- !u!1 &324201405
 GameObject:
   m_ObjectHideFlags: 0
@@ -650,7 +652,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8868fc24decd05e40b88174ab164b657, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  elasticity: 0.75
+  elasticity: 1
+  damageMultiplier: 0.6
 --- !u!1 &747943603
 GameObject:
   m_ObjectHideFlags: 0
@@ -969,6 +972,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   elasticity: 1
+  damageMultiplier: 0.6
 --- !u!1 &1347505019
 GameObject:
   m_ObjectHideFlags: 0
@@ -1124,7 +1128,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8868fc24decd05e40b88174ab164b657, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  elasticity: 0.5
+  elasticity: 1
+  damageMultiplier: 0.6
 --- !u!1 &1544443831 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1883854870026651927, guid: afb30945538a837429b920c372b3ff52, type: 3}

--- a/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
@@ -224,6 +224,7 @@ GameObject:
   - component: {fileID: 9170336539225875185}
   - component: {fileID: 924639791968285090}
   - component: {fileID: 4482247653229570460}
+  - component: {fileID: 7072003515269941083}
   m_Layer: 0
   m_Name: PlayerPrefab
   m_TagString: Player
@@ -394,6 +395,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   vs: {fileID: 924639791968285090}
+--- !u!114 &7072003515269941083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6273220948599445249}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25e4872b3bbe5c44c8d905b01671f21e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: {fileID: 3912680492871693738}
+  vs: {fileID: 924639791968285090}
+  sourcesToIgnore:
+  - playerMovement
+  - playerDash
 --- !u!1 &6737187360258442515
 GameObject:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/DamageOnBounce.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/DamageOnBounce.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(BounceScript))]
+public class DamageOnBounce : MonoBehaviour
+{
+    [SerializeField]
+    private Health health;
+    [SerializeField]
+    private VelocitySetter vs;
+    [SerializeField]
+    private List<string> sourcesToIgnore;
+    
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        GetComponent<BounceScript>().onBounce += OnBounce;
+    }
+
+    private void OnBounce(Collision2D collision, WallData data)
+    {
+        float magnitude = 0;
+        foreach(string source in vs.sources.Keys)
+        {
+            if(vs.QuerySource(source, out Vector2 vel) && !sourcesToIgnore.Contains(source))
+            {
+                magnitude += vel.magnitude;
+            }
+        }
+        float damage = Mathf.Clamp(magnitude * data.damageMultiplier * GlobalSettings.wallDamageCoeff, float.NegativeInfinity, GlobalSettings.wallDamageCap);
+        Debug.Log("Damage: " + damage);
+        health.TakeDamage(damage);
+    }
+
+   
+}

--- a/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/DamageOnBounce.cs.meta
+++ b/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/DamageOnBounce.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25e4872b3bbe5c44c8d905b01671f21e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WhenPushComesToShove/Assets/3-Scripts/GlobalSettings.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/GlobalSettings.cs
@@ -5,4 +5,6 @@ using UnityEngine;
 public static class GlobalSettings
 {
    public readonly static float frictionCoeff = .6f;
+   public readonly static float wallDamageCoeff = 1;
+   public readonly static float wallDamageCap = 20.0f;
 }

--- a/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerConfigManager.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerConfigManager.cs
@@ -103,7 +103,7 @@ public class PlayerConfigManager : MonoBehaviour
             levelInitRef.SpawnPlayer(input.playerIndex);
         }
 
-        if (playerConfigs.Count >= 1)
+        if (playerConfigs.Count >= maxPlayers)
             levelInitRef.lockPlayerSpawn = true;
     }
 }

--- a/WhenPushComesToShove/Assets/3-Scripts/Utilities/Physics/BounceScript.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Utilities/Physics/BounceScript.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using UnityEngine;
 using DG.Tweening;
 
+public delegate void BounceDelegate(Collision2D collision, WallData data);
+
 [RequireComponent(typeof(Collider2D))]
 public class BounceScript : MonoBehaviour
 {
+    public event BounceDelegate onBounce; 
     [SerializeField]
     private VelocitySetter vs;
 
@@ -13,8 +16,10 @@ public class BounceScript : MonoBehaviour
     private void OnCollisionEnter2D(Collision2D collision)
     {
         WallData data = collision.collider.GetComponent<WallData>();
+
         if (data != null)
         {
+            onBounce?.Invoke(collision, data);
             //Can't modify the source list during loop
             Dictionary<string, Vector2> changes = new Dictionary<string, Vector2>();
             Vector2 N = collision.GetContact(0).normal;

--- a/WhenPushComesToShove/Assets/3-Scripts/Utilities/Physics/WallData.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Utilities/Physics/WallData.cs
@@ -8,4 +8,6 @@ public class WallData : MonoBehaviour
     [Tooltip("How much an object will bounce off of this wall (0 for no bounce, 1 for no speed lost")]
     [Range(0,1)]
     public float elasticity;
+    [Tooltip("How much to multiply the velocity-based damage multiplier")]
+    public float damageMultiplier;
 }


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
- We wanted there to be damage dealt upon wall bounce

**What changes were made:**
-  Players now take damage on wall bounce from knockback.

**Any concerns regarding the changes made in this request?**
There is now a damage field to wall data, will likely have to add support for that into level editor
Wall bounce damage not added to slime enemy, as rework of slime isn't merged in yet
