### PR TITLE
Reset player on room change

### DIFF
--- a/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/PlayerHealth.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/PlayerHealth.cs
@@ -5,6 +5,20 @@ using UnityEngine;
 public class PlayerHealth : Health
 {
     public PlayerInputHandler playerRef;
+
+
+    private void OnEnable()
+    {
+        LevelManager.onNewRoom += ResetHealth;
+        LevelManager.onEndGame += ResetHealth;
+    }
+
+    private void OnDisable()
+    {
+        LevelManager.onNewRoom -= ResetHealth;
+        LevelManager.onEndGame -= ResetHealth;
+    }
+
     public override void Die()
     {
         playerRef.sr.color = new Color(playerRef.sr.color.r, playerRef.sr.color.g, playerRef.sr.color.b, .5f);

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
@@ -47,6 +47,13 @@ public class LevelManager : MonoBehaviour
 
             onNewRoom();
         }
+
+        //Temp code to reset the game fully
+        if (Input.GetKeyDown(KeyCode.Q))
+        {
+            ClearEnemies();
+            onEndGame();
+        }
     }
 
     //Will ensure that only the current room on the path will show up

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/PathGenerator.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/PathGenerator.cs
@@ -104,7 +104,7 @@ public class PathGenerator : MonoBehaviour
 
         if (arena == null)
         {
-            Debug.LogError("No arena available for this path. Loading in default arena");
+            Debug.LogWarning("No arena available for this path. Loading in default arena");
             path.Add(Resources.Load<GameObject>("Levels/Arenas/DefaultArena"));
         }
             

--- a/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerInventory.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerInventory.cs
@@ -15,12 +15,25 @@ public class PlayerInventory : MonoBehaviour
     private PlayerInputHandler inputHandler;
     private List<LootData> inRangeLoot;
 
+    private LootManager lootManager;
+    private void OnEnable()
+    {
+        LevelManager.onEndGame += ResetLoot;
+    }
+
+    private void OnDisable()
+    {
+        LevelManager.onEndGame -= ResetLoot;
+    }
+
     public void Awake()
     {
         inputHandler = transform.parent.GetComponentInChildren<PlayerInputHandler>();
 
         passiveLoot = new List<LootData>();
         inRangeLoot = new List<LootData>();
+
+        lootManager = GameObject.Find("LootManager").GetComponent<LootManager>();
     }
 
     public void EquipItem(LootData loot) //TODO Prompt player for loot switch in some way
@@ -45,6 +58,7 @@ public class PlayerInventory : MonoBehaviour
 
                     lightShoveScript.onLightShove += loot.Action;
                     loot.gameObject.SetActive(false);
+                    lootManager.droppedLoot.Remove(loot);
                 }
                 //Otherwise assign equiping the loot to the select action
                 else
@@ -68,6 +82,7 @@ public class PlayerInventory : MonoBehaviour
 
                     heavyShoveScript.onHeavyShove += loot.Action;
                     loot.gameObject.SetActive(false);
+                    lootManager.droppedLoot.Remove(loot);
                 }
                 //Otherwise assign equiping the loot to the select action
                 else
@@ -81,7 +96,7 @@ public class PlayerInventory : MonoBehaviour
                 //Add the loot
                 passiveLoot.Add(loot);
                 loot.OnEquip(transform.parent);
-
+                lootManager.droppedLoot.Remove(loot);
                 //Trigger the Pasive Action
                 loot.Action();
 
@@ -109,18 +124,24 @@ public class PlayerInventory : MonoBehaviour
     /// Drops the current loot in the existing category
     /// </summary>
     /// <param name="type"></param>
-    public void DropLoot(LootData.LootType type)
+    public void DropLoot(LootData.LootType type, bool dropOnGround = true)
     {
         switch (type)
         {
+            
             case LootData.LootType.Light:
+                
                 lightShoveLoot.OnUnequip(transform.parent);
                 lightShoveScript.onLightShove = null;
                 lightShoveScript.EnableBaseLightShove();
 
-                lightShoveLoot.transform.position = transform.parent.position;
-                lightShoveLoot.gameObject.SetActive(true);
+                if (dropOnGround)
+                {
+                    lightShoveLoot.transform.position = transform.parent.position;
+                    lightShoveLoot.gameObject.SetActive(true);
+                }
 
+                lootManager.droppedLoot.Add(lightShoveLoot);
                 lightShoveLoot = null;
                 break;
             case LootData.LootType.Heavy:
@@ -128,9 +149,12 @@ public class PlayerInventory : MonoBehaviour
                 heavyShoveScript.onHeavyShove = null;
                 heavyShoveScript.EnableBaseHeavyShove();
 
-                heavyShoveLoot.transform.position = transform.parent.position;
-                heavyShoveLoot.gameObject.SetActive(true);
-
+                if (dropOnGround)
+                {
+                    heavyShoveLoot.transform.position = transform.parent.position;
+                    heavyShoveLoot.gameObject.SetActive(true);
+                }
+                lootManager.droppedLoot.Add(heavyShoveLoot);
                 heavyShoveLoot = null;
                 break;
             case LootData.LootType.Passive: //Not sure if we want players to drop passive loot
@@ -140,6 +164,24 @@ public class PlayerInventory : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Gets rid of all players loop
+    /// </summary>
+    void ResetLoot()
+    {
+        if(lightShoveLoot != null)
+            DropLoot(lightShoveLoot.lootType, false);
+
+        if(heavyShoveLoot != null)
+            DropLoot(heavyShoveLoot.lootType, false);
+
+        foreach(LootData loot in passiveLoot)
+        {
+            loot.OnUnequip(transform.parent);
+        }
+
+        passiveLoot.Clear();
+    }
     /// <summary>
     /// Removes the loot from being able to be picked up
     /// </summary>


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
- Player loot and health weren't resetting properly.

**What changes were made:**
- Player health resets on end game and room change.
- Player loot gets rest on end game.

**Delete this branch?**
Yes

**Any concerns regarding the changes made in this request?**
Changes were made to address some of the loot problems, but I think this change fixed a lot of them. They haven't been stress tested though.