### PR TITLE
Added terminal velocity

### DIFF
--- a/WhenPushComesToShove/Assets/3-Scripts/GlobalSettings.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/GlobalSettings.cs
@@ -6,6 +6,7 @@ public static class GlobalSettings
 {
    //Physics
    public readonly static float frictionCoeff = .6f;
+   public readonly static float terminalVelocity = 45.0f;
 
    //Wall Bounce Damage
    public readonly static float wallDamageCoeff = 1;

--- a/WhenPushComesToShove/Assets/3-Scripts/Utilities/Navigation/MovementController.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Utilities/Navigation/MovementController.cs
@@ -54,11 +54,19 @@ public class MovementController : MonoBehaviour
 
     public void LockMovement()
     {
+        if(move == null)
+        {
+            Init();
+        }
         move.movementLocked = true;
     }
 
     public void UnlockMovement()
     {
+        if(move == null)
+        {
+            Init();
+        }
         move.movementLocked = false;
     }
 

--- a/WhenPushComesToShove/Assets/3-Scripts/Utilities/Physics/ProjectileMode.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Utilities/Physics/ProjectileMode.cs
@@ -49,6 +49,8 @@ public class ProjectileMode : MonoBehaviour
         onPModeEnter?.Invoke();
     }
 
+
+
     // Update is called once per frame
     void FixedUpdate()
     {
@@ -60,6 +62,10 @@ public class ProjectileMode : MonoBehaviour
         }
         frames++;
 
+        if(Velocity.magnitude > GlobalSettings.terminalVelocity)
+        {
+            rb.velocity = Vector2.ClampMagnitude(rb.velocity, GlobalSettings.terminalVelocity);
+        }
     }
 
     void OnDisable()


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
-  There really should be a terminal velocity so physics objects don't go flying
- Null references on room start in lock movement

**What changes were made:**
- Lock movement will init if neccessary
- Velocity is clamped in projectile mode

**Delete this branch?**
Yes
**Any concerns regarding the changes made in this request?**
