### PR TITLE
Fixing movement locks overriding each other

### DIFF
--- a/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
@@ -5313,7 +5313,7 @@ MonoBehaviour:
   pMode: {fileID: 0}
   dashSpeed: 10000
   dashTime: 0.75
-  collider: {fileID: 0}
+  collider: {fileID: 7738541377467117733}
 --- !u!114 &1495853962286914703
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerMovementScript.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerMovementScript.cs
@@ -20,6 +20,7 @@ public class PlayerMovementScript : Move
 
     private bool lockMovement = false;
     private Coroutine movementUnlockRoutine;
+    private int forceMovementLocks = 0;
 
     #region Properties
     public Vector3 GetMoveDirection()
@@ -48,7 +49,7 @@ public class PlayerMovementScript : Move
     //https://www.youtube.com/watch?v=qdskE8PJy6Q&ab_channel=ToyfulGames
     private void FixedUpdate()
     {
-        if (lockMovement)
+        if (forceMovementLocks > 0)
         {
             SetMoveInputVector(Vector2.zero);
         }
@@ -125,7 +126,8 @@ public class PlayerMovementScript : Move
     /// <param name="cooldown"></param>
     public void LockMovementForTime(float cooldown)
     {
-        lockMovement = true;
+        //lockMovement = true;
+        forceMovementLocks++;
         movementUnlockRoutine = StartCoroutine(MovementLockCooldown(cooldown));
     }
 
@@ -137,7 +139,8 @@ public class PlayerMovementScript : Move
     public IEnumerator MovementLockCooldown(float cooldown)
     {
         yield return new WaitForSeconds(cooldown);
-        lockMovement = false;
+        //lockMovement = false;
+        forceMovementLocks--;
     }
 
     /// <summary>
@@ -150,7 +153,8 @@ public class PlayerMovementScript : Move
             StopCoroutine(movementUnlockRoutine);
         }
 
-        lockMovement = true;
+        //lockMovement = true;
+        forceMovementLocks++;
     }
 
     /// <summary>
@@ -158,7 +162,8 @@ public class PlayerMovementScript : Move
     /// </summary>
     public void ForceUnlockMovement()
     {
-        lockMovement = false;
+        //lockMovement = false;
+        forceMovementLocks--;
     }
     #endregion
 }


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
- Players were able to move during the room countdown

**What changes were made:**
- Changed movement lock to an int instead of a bool so that multiple can exist at once

**Delete this branch?**
- Sure

**Any concerns regarding the changes made in this request?**
