### PR TITLE
Controller Rumble Fixes = Other Small Things

### DIFF
--- a/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
@@ -54,6 +54,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentState: {fileID: 0}
   target: {fileID: 0}
+  printInfo: 0
   anim: {fileID: 8174910203704807974}
   pMode: {fileID: 519120853313958755}
   dashScript: {fileID: 3186559500755933933}
@@ -149,6 +150,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   id: heavy
   anim: {fileID: 0}
+  heavyShoveScript: {fileID: 0}
 --- !u!114 &2033113999610898427
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5293,7 +5295,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   heavyShoveIsCharging: 0
   heavyShoveCharge: 0
-  heavyShoveChargeTime: 1
+  lowTierChargeTime: 0.3
+  midTierChargeTime: 0.5
+  highTierChargeTime: 1
+  chargeLevel: 0
   speedDecrease: 0.2
   hitbox: {fileID: 5245641597600162962}
   cooldown: 0.35
@@ -6245,6 +6250,10 @@ PrefabInstance:
       propertyPath: owner
       value: 
       objectReference: {fileID: 6273220948599445249}
+    - target: {fileID: 6854435290789191521, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
+      propertyPath: handler
+      value: 
+      objectReference: {fileID: 7896129718564220858}
     - target: {fileID: 6854435290789191532, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
       propertyPath: m_Color.b
       value: 0.7426162
@@ -6351,6 +6360,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   damage: 20
+--- !u!114 &7896129718564220858
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5245641597600162963}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7373120e58469145a57596344049d18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tagsToIgnore:
+  - GhostShove
 --- !u!4 &5245641597600162974 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6854435290789191533, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
@@ -6593,6 +6616,10 @@ PrefabInstance:
       propertyPath: owner
       value: 
       objectReference: {fileID: 6273220948599445249}
+    - target: {fileID: 6854435290789191521, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
+      propertyPath: handler
+      value: 
+      objectReference: {fileID: 6467932630811310649}
     - target: {fileID: 6854435290789191532, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
       propertyPath: m_Color.b
       value: 0.9607843
@@ -6688,6 +6715,19 @@ MonoBehaviour:
   type: 0
   strength: 9000
   axis: 0
+--- !u!114 &6467932630811310649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763200320402767856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7373120e58469145a57596344049d18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tagsToIgnore: []
 --- !u!114 &763200320402767857 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6854435290789191521, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}

--- a/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/PlayerHealth.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/CombatScripts/PlayerHealth.cs
@@ -31,7 +31,12 @@ public class PlayerHealth : Health
         playerMat = this.gameObject.GetComponentInParent<SpriteRenderer>().material;
         Debug.Log("turning white woo");
         playerMat.SetInt("_IsDamaged", 1);
-        playerInputRef.rumble.RumbleLinear(.4f, 0, .8f, 0, .2f, false);
+
+        if (!dead)
+        {
+            playerInputRef.rumble.RumbleLinear(.4f, 0, .8f, 0, .2f, false);
+        }
+
         StartCoroutine(DamageFlash());
     }
 

--- a/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerHeavyShoveScript.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerHeavyShoveScript.cs
@@ -85,7 +85,10 @@ public class PlayerHeavyShoveScript : MonoBehaviour
             //Assign Release Method
             context.action.canceled += WaitForChargeRelease;
 
-            handler.rumble.RumbleLinear(0, .5f, 0, .5f, highTierChargeTime, true);
+            if (!handler.playerConfig.IsDead)
+            {
+                handler.rumble.RumbleLinear(0, .5f, 0, .5f, highTierChargeTime, true);
+            }
 
             heavyShoveIsCharging = true;
             heavyShoveCharge = 0;
@@ -184,6 +187,10 @@ public class PlayerHeavyShoveScript : MonoBehaviour
     private IEnumerator ShoveRumbleDelay(float delay)
     {
         yield return new WaitForSeconds(delay);
-        handler.rumble.RumbleConstant(1.7f, 2f, .4f);
+
+        if (!handler.playerConfig.IsDead)
+        {
+            handler.rumble.RumbleConstant(1.7f, 2f, .4f);
+        }
     }
 }

--- a/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerInputHandler.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerInputHandler.cs
@@ -108,7 +108,6 @@ public class PlayerInputHandler : MonoBehaviour
             if (!performingAction && !heavyShoveScript.heavyShoveIsCharging)
             {
                 lightShoveScript.OnLightShoveStart(obj);
-                rumble.RumbleConstant(.2f, .4f, .1f);
             }
             
         }

--- a/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerMovementScript.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Player Scripts/PlayerMovementScript.cs
@@ -59,7 +59,7 @@ public class PlayerMovementScript : Move
         Vector2 unitMove = moveInputVector;
       
         //If moving but not aiming, default aim to move direction
-        if (aimInputVector == Vector2.zero && unitMove != Vector2.zero)
+        if (aimInputVector == Vector2.zero && unitMove != Vector2.zero && forceAimLocks <=  0)
         {
             player.right = unitMove.normalized;
             aimTriangle.eulerAngles = new Vector3(fixedX, fixedY, player.transform.eulerAngles.z);
@@ -155,6 +155,7 @@ public class PlayerMovementScript : Move
     {
         if (movementUnlockRoutine != null)
         {
+            forceMovementLocks--;
             StopCoroutine(movementUnlockRoutine);
         }
 

--- a/WhenPushComesToShove/Assets/3-Scripts/Utilities/Hitboxes/RumbleOnHit.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Utilities/Hitboxes/RumbleOnHit.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RumbleOnHit : HitHandler
+{
+    public override void ReceiveHit(HitEvent e)
+    {
+        //Rather than getting messy with tags just going to ensure that only rumbles when both players are either dead or not
+        if (e.hurtbox.owner.TryGetComponent<PlayerInputHandler>(out PlayerInputHandler handler))
+        {
+            bool player1Death = e.hitbox.owner.GetComponentInChildren<PlayerInputHandler>().playerConfig.IsDead;
+            bool player2Death = handler.playerConfig.IsDead;
+
+            if (player1Death == player2Death)
+            {
+                ControllerRumble rumble = e.hitbox.owner.GetComponentInChildren<ControllerRumble>();
+                rumble.RumbleConstant(.1f, .3f, .1f);
+            }
+        }
+        else
+        {
+            ControllerRumble rumble = e.hitbox.owner.GetComponentInChildren<ControllerRumble>();
+            rumble.RumbleConstant(.1f, .3f, .1f);
+        }
+
+
+
+
+
+    }
+}

--- a/WhenPushComesToShove/Assets/3-Scripts/Utilities/Hitboxes/RumbleOnHit.cs.meta
+++ b/WhenPushComesToShove/Assets/3-Scripts/Utilities/Hitboxes/RumbleOnHit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7373120e58469145a57596344049d18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WhenPushComesToShove/Assets/PlayerControls.cs
+++ b/WhenPushComesToShove/Assets/PlayerControls.cs
@@ -196,7 +196,7 @@ public partial class @PlayerControls : IInputActionCollection2, IDisposable
                 {
                     ""name"": """",
                     ""id"": ""78d4020c-df70-4449-b67f-9efcf9bb9dde"",
-                    ""path"": ""<Gamepad>/leftShoulder"",
+                    ""path"": ""<Gamepad>/leftTrigger"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",

--- a/WhenPushComesToShove/Assets/PlayerControls.inputactions
+++ b/WhenPushComesToShove/Assets/PlayerControls.inputactions
@@ -174,7 +174,7 @@
                 {
                     "name": "",
                     "id": "78d4020c-df70-4449-b67f-9efcf9bb9dde",
-                    "path": "<Gamepad>/leftShoulder",
+                    "path": "<Gamepad>/leftTrigger",
                     "interactions": "",
                     "processors": "",
                     "groups": "",


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
- We have too much controller rumble
- Dead players should not feel all the rumble

**What changes were made:**
- Remove light shove rumble
- Added small rumble on hit 
- Remove dead players from feeling all rumble except on hit
- Fix players from locking themselves into not being able to move
- Fix players being able to rotate hitbox on move

**Delete this branch?**
- Sure

**Any concerns regarding the changes made in this request?**
