### PR TITLE
Fixed the Victory room not showing up a second time 

### DIFF
--- a/WhenPushComesToShove/Assets/1-Scenes/TestScenes/LevelEditorScene.unity
+++ b/WhenPushComesToShove/Assets/1-Scenes/TestScenes/LevelEditorScene.unity
@@ -1393,7 +1393,6 @@ GameObject:
   - component: {fileID: 1161639663}
   - component: {fileID: 1161639665}
   - component: {fileID: 1161639666}
-  - component: {fileID: 1161639667}
   m_Layer: 0
   m_Name: Level Editor
   m_TagString: Untagged
@@ -1567,22 +1566,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   allEnemies: []
---- !u!114 &1161639667
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1161639660}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00ca3362c77c0f6408f6ac92a2695cd6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  waveDelays: []
-  currentWave: -1
-  complete: 0
-  delayAllWaveTime: 0
 --- !u!1 &1317946488
 GameObject:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Lobby.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Lobby.prefab
@@ -3364,7 +3364,6 @@ GameObject:
   - component: {fileID: 1755209493023897844}
   - component: {fileID: 775442832769645502}
   - component: {fileID: 1750519237089320605}
-  - component: {fileID: 7362869894602280755}
   m_Layer: 0
   m_Name: Lobby
   m_TagString: Untagged
@@ -3404,22 +3403,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5e5119f601983714e8664f9b2847511c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hazards:
-  - hazard: 0
-    level: 0
-  - hazard: 2
-    level: 0
-  - hazard: 1
-    level: 0
-  - hazard: 3
-    level: 0
-  enemyStats:
-  - enemy: 0
-    level: 0
-  - enemy: 1
-    level: 0
-  - enemy: 2
-    level: 0
   playerSpawns:
   - {fileID: 8318899948142839505}
   - {fileID: 1982447994706698772}
@@ -3428,9 +3411,7 @@ MonoBehaviour:
   enemySpawns: []
   levelType: 0
   game: 0
-  waveManager: {fileID: 7362869894602280755}
   teamLevel: 0
-  enemySpawnProps: []
 --- !u!156049354 &1750519237089320605
 Grid:
   m_ObjectHideFlags: 0
@@ -3443,22 +3424,6 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
---- !u!114 &7362869894602280755
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6254306470328373913}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00ca3362c77c0f6408f6ac92a2695cd6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  waveDelays: []
-  currentWave: -1
-  complete: 0
-  delayAllWaveTime: 0
 --- !u!1 &6273454438970049299
 GameObject:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/DodgeballGame.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/DodgeballGame.prefab
@@ -294,6 +294,7 @@ MonoBehaviour:
   endCondition: {fileID: 6634862556189966687}
   data: {fileID: 7285882888532369635}
   canPlayersTakeDamage: 1
+  pauseMovementAtStart: 1
   dodgeballSpawner: {fileID: 3580809651167699746}
 --- !u!1 &1805791060
 GameObject:
@@ -6289,7 +6290,6 @@ GameObject:
   - component: {fileID: 5810466408425846982}
   - component: {fileID: 4504170673408540922}
   - component: {fileID: 4844155420199255257}
-  - component: {fileID: 6905185167733970435}
   m_Layer: 0
   m_Name: DodgeballGame
   m_TagString: Untagged
@@ -6329,12 +6329,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5e5119f601983714e8664f9b2847511c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hazards:
-  - hazard: 0
-    level: 0
-  enemyStats:
-  - enemy: 0
-    level: 0
   playerSpawns:
   - {fileID: 8463615690127265867}
   - {fileID: 3938775462489440019}
@@ -6343,9 +6337,7 @@ MonoBehaviour:
   enemySpawns: []
   levelType: 3
   game: 1
-  waveManager: {fileID: 6905185167733970435}
   teamLevel: 0
-  enemySpawnProps: []
 --- !u!156049354 &4844155420199255257
 Grid:
   m_ObjectHideFlags: 0
@@ -6358,22 +6350,6 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
---- !u!114 &6905185167733970435
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3115093129980057568}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00ca3362c77c0f6408f6ac92a2695cd6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  waveDelays: []
-  currentWave: -1
-  complete: 0
-  delayAllWaveTime: 0
 --- !u!1 &5809279988283899252
 GameObject:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/Hot Potato.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/Hot Potato.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 805013608764250826}
   - component: {fileID: 805013608764250821}
   - component: {fileID: 805013608764250820}
-  - component: {fileID: 805013608764250823}
   m_Layer: 0
   m_Name: Hot Potato
   m_TagString: Untagged
@@ -51,8 +50,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5e5119f601983714e8664f9b2847511c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hazards: []
-  enemyStats: []
   playerSpawns:
   - {fileID: 4719234336218113262}
   - {fileID: 7720546851137592959}
@@ -61,9 +58,7 @@ MonoBehaviour:
   enemySpawns: []
   levelType: 2
   game: 3
-  waveManager: {fileID: 805013608764250823}
   teamLevel: 0
-  enemySpawnProps: []
 --- !u!156049354 &805013608764250820
 Grid:
   m_ObjectHideFlags: 0
@@ -76,22 +71,6 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
---- !u!114 &805013608764250823
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 805013608764250822}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00ca3362c77c0f6408f6ac92a2695cd6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  waveDelays: []
-  currentWave: -1
-  complete: 0
-  delayAllWaveTime: 0
 --- !u!1 &2767432924756996349
 GameObject:
   m_ObjectHideFlags: 0
@@ -180,6 +159,7 @@ MonoBehaviour:
   endCondition: {fileID: 6580719124436952548}
   data: {fileID: 6523163525860134486}
   canPlayersTakeDamage: 1
+  pauseMovementAtStart: 1
   spawner: {fileID: 5482981596809396173}
   startBombSpawnInterval: 5
   endBombSpawnInterval: 3

--- a/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/SoccerGame.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/SoccerGame.prefab
@@ -8832,7 +8832,6 @@ GameObject:
   - component: {fileID: 4804693292107850613}
   - component: {fileID: 8082681146408211673}
   - component: {fileID: 7778475532935669128}
-  - component: {fileID: 5885948976961785816}
   m_Layer: 0
   m_Name: SoccerGame
   m_TagString: Untagged
@@ -8872,12 +8871,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5e5119f601983714e8664f9b2847511c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hazards:
-  - hazard: 0
-    level: 0
-  enemyStats:
-  - enemy: 0
-    level: 0
   playerSpawns:
   - {fileID: 6075558046354513601}
   - {fileID: 856199516552640701}
@@ -8886,9 +8879,7 @@ MonoBehaviour:
   enemySpawns: []
   levelType: 3
   game: 1
-  waveManager: {fileID: 5885948976961785816}
   teamLevel: 0
-  enemySpawnProps: []
 --- !u!156049354 &7778475532935669128
 Grid:
   m_ObjectHideFlags: 0
@@ -8901,22 +8892,6 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
---- !u!114 &5885948976961785816
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8829601026546890495}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00ca3362c77c0f6408f6ac92a2695cd6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  waveDelays: []
-  currentWave: -1
-  complete: 0
-  delayAllWaveTime: 0
 --- !u!1 &9181059686184593228
 GameObject:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/SumoGame.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/SumoGame.prefab
@@ -315,7 +315,6 @@ MonoBehaviour:
   respawner: {fileID: 182331866953112179}
   timeToThreaten: 4
   timeToActivateFromThreaten: 2
-  data: {fileID: 709529347168073206}
 --- !u!1 &1805791060
 GameObject:
   m_ObjectHideFlags: 0
@@ -6222,7 +6221,6 @@ GameObject:
   - component: {fileID: 5810466408425846982}
   - component: {fileID: 4504170673408540922}
   - component: {fileID: 4844155420199255257}
-  - component: {fileID: 6905185167733970435}
   m_Layer: 0
   m_Name: SumoGame
   m_TagString: Untagged
@@ -6262,12 +6260,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5e5119f601983714e8664f9b2847511c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  hazards:
-  - hazard: 0
-    level: 0
-  enemyStats:
-  - enemy: 0
-    level: 0
   playerSpawns:
   - {fileID: 8463615690127265867}
   - {fileID: 6306462121216221137}
@@ -6276,9 +6268,7 @@ MonoBehaviour:
   enemySpawns: []
   levelType: 2
   game: 4
-  waveManager: {fileID: 6905185167733970435}
   teamLevel: 0
-  enemySpawnProps: []
 --- !u!156049354 &4844155420199255257
 Grid:
   m_ObjectHideFlags: 0
@@ -6291,22 +6281,6 @@ Grid:
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
---- !u!114 &6905185167733970435
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3115093129980057568}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00ca3362c77c0f6408f6ac92a2695cd6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  waveDelays: []
-  currentWave: -1
-  complete: 0
-  delayAllWaveTime: 0
 --- !u!1 &3323974005192675966
 GameObject:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
@@ -124,6 +124,7 @@ public class LevelManager : MonoBehaviour
       
 
         currentRoomIndex = 0;
+        endRoomSpawned = false;
         //currentRoomIndex = path.Count;
         //repeatPath = true;
         //ShowRoom();     

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelProperties.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelProperties.cs
@@ -10,17 +10,13 @@ public enum LevelType { Lobby, Dungeon, Arena, TwoTwo, ThreeOne, Modifier};
 public class LevelProperties : MonoBehaviour
 {
     //Properties needed for the level editor
-    public HazardDifficulty.HazardStats[] hazards;
-    public EnemyDifficulty.EnemyLevelStats[] enemyStats;
     public GameObject[] playerSpawns;
     public GameObject[] enemySpawns;
     public LevelType levelType;
     public Minigame game;
-    public WaveManager waveManager;
 
     [HideInInspector] public bool teamLevel;
 
-    [HideInInspector] public List<EnemySpawnPoint> enemySpawnProps = new List<EnemySpawnPoint>();
 
     private void OnEnable()
     {

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/PathGenerator.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/PathGenerator.cs
@@ -16,7 +16,7 @@ public class PathGenerator : MonoBehaviour
     public List<LevelProperties> availableLevels = new List<LevelProperties>();
 
     //Any games that have already been played that can be filter out of the available levels
-    [HideInInspector] public List<LevelProperties> playedLevels = new List<LevelProperties>();
+    public List<LevelProperties> playedLevels = new List<LevelProperties>();
 
     [Header("Path properties")]
     [SerializeField] private int numOfGames;
@@ -51,6 +51,12 @@ public class PathGenerator : MonoBehaviour
         if(games.Count == 1 && games[0] == Minigame.All)
         {
             availableLevels = new List<LevelProperties>(allLevels);
+
+            foreach(LevelProperties prop in playedLevels)
+            {
+                availableLevels.Remove(prop);
+            }
+
             return;
         }
 
@@ -60,6 +66,10 @@ public class PathGenerator : MonoBehaviour
             {
                 if(prop.game == type)
                 {
+                    //Don't add to available list if game has been played
+                    if (playedLevels.Contains(prop))
+                        break;
+
                     availableLevels.Add(prop);
                     break;
                 }

--- a/WhenPushComesToShove/Assets/3-Scripts/Tools/Level Editor/LevelEditor.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Tools/Level Editor/LevelEditor.cs
@@ -83,12 +83,6 @@ public class LevelEditor : MonoBehaviour
             //Update stats
             LevelProperties selectedProps = selectedLevel.GetComponent<LevelProperties>();
 
-            //Hazard stats
-            hazardStats = selectedProps.hazards;
-
-            //Enemy stats
-            enemyStats = selectedProps.enemyStats;
-
             levelType = selectedProps.levelType;
 
             //Update the sprite layers to match the selected Level
@@ -338,12 +332,6 @@ public class CustomLevelEditor : Editor
 
             levelProp.enemySpawns = enemySpawns.ToArray();
             enemySpawns.Clear();
-
-            //Check to make sure that there's at least one hazard stat
-            levelProp.hazards = level.hazardStats;
-
-
-            levelProp.enemyStats = level.enemyStats;
 
 
             if (root.name == "")

--- a/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638100782721190055
+  lastModified: 638101554938100841
   FileSizes: []
   Exists: 1
 --- !u!114 &-1468950982031199481
@@ -33,7 +33,7 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638100782721200029
+  lastModified: 638101554938170655
   FileSizes:
   - Name: 
     Value: 908
@@ -61,7 +61,7 @@ MonoBehaviour:
   - {fileID: -1808526897751299166}
   StringsBanks:
   - {fileID: -1468950982031199481}
-  cacheTime: 638100782721409470
+  cacheTime: 638101554938479825
   cacheVersion: 131601
 --- !u!114 &2291896933958292084
 MonoBehaviour:
@@ -105,6 +105,6 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Music.bank
   Name: Music
   StudioPath: bank:/Music
-  lastModified: 638100782721409470
+  lastModified: 638101554938479825
   FileSizes: []
   Exists: 1

--- a/WhenPushComesToShove/fmod_editor.log
+++ b/WhenPushComesToShove/fmod_editor.log
@@ -7,7 +7,7 @@
 [LOG] OutputWASAPI::init                       : Output buffer size: 4096 samples, latency: 0.00ms, period: 10.00ms, DSP buffer: 1024 * 4
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 000001DB45E053E8 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 000002773F24E2A8 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.


### PR DESCRIPTION


**What issue(s) is this request trying to address:**
- There were several issues with the path generator that would either cause the game to break or not show the victory room

**What changes were made:**
- Victory room now shows up after more than one playthrough
- Available games list updates properly when a modifier is chosen so it doesn't blue screen the game
- Wave Manager was removed from the level editor, the lobby, and all of the minigames

**Delete this branch?**
Yes

**Any concerns regarding the changes made in this request?**
