### PR TITLE
Modifier fixes

### DIFF
--- a/WhenPushComesToShove/Assets/1-Scenes/MainScene.unity
+++ b/WhenPushComesToShove/Assets/1-Scenes/MainScene.unity
@@ -323,7 +323,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   modifierPoolSO: {fileID: 11400000, guid: caf1f156d9cc7cf45b64304a625d617c, type: 2}
-  debugList: {fileID: 0}
+  debugList: {fileID: 11400000, guid: 67f770b2453a3b64fb7ee84a08e9ff22, type: 2}
 --- !u!4 &514692959
 Transform:
   m_ObjectHideFlags: 0
@@ -892,7 +892,8 @@ MonoBehaviour:
   playedLevels: []
   numOfGames: 4
   numOfRooms: 0
-  path: []
+  path:
+  - {fileID: 805013608764250822, guid: d33d8fc8c691af7419205acae4faa370, type: 3}
 --- !u!4 &1589640427
 Transform:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/3-Scripts/GameState.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/GameState.cs
@@ -4,13 +4,30 @@ using UnityEngine;
 
 public static class GameState
 {
-    static public List<Transform> players = new List<Transform>();
-    static public List<HealthBar> playerHealthBars = new List<HealthBar>();
+    public static List<Transform> players = new List<Transform>();
+    public static List<HealthBar> playerHealthBars = new List<HealthBar>();
     public static LevelType currentRoomType;
     public static bool damageEnabled = true;
     public static int[] playerScores = new int[4];
     public static string[] playerNames = new string[] { "Red", "Blue", "Green", "Yellow" };
     public static PathGenerator pathGenerator;
+
+    private static ModifierManager modifierManager;
+
+    //Properties
+    public static ModifierManager ModifierManager
+    {
+        get
+        {
+            if(modifierManager == null)
+            {
+                //This is safe because we never change scenes
+                modifierManager = GameObject.FindGameObjectWithTag("ModifierManager").GetComponent<ModifierManager>();
+            }
+            return modifierManager;
+        }
+    }
+
 
     //Global Modifiers
     public static float dragModifier = 1;

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
@@ -14,8 +14,6 @@ public class LevelManager : MonoBehaviour
     public static Action onNewRoom;
     public static Action onModifierRoom;
     public static Action onEndGame;
-    [SerializeField]
-    private ModifierManager modifierManager;
     private bool endRoomSpawned = false;
 
     private void OnEnable()

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
@@ -35,6 +35,7 @@ public class LevelManager : MonoBehaviour
    
         pathGen = GetComponent<PathGenerator>();
         damageEnabler = GetComponent<DamageEnabler>();
+        
     }
     // Start is called before the first frame update
     void Start()
@@ -109,7 +110,7 @@ public class LevelManager : MonoBehaviour
         if(levelProp.transform.GetChild(3).TryGetComponent<MinigameLogic>(out MinigameLogic logic))
         {
             logic.Init();
-
+            GameState.ModifierManager.InitMinigame(levelProp.transform);
         }
 
         //Update Logging

--- a/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/MinigameLogic.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/MinigameLogic.cs
@@ -58,7 +58,7 @@ public abstract class MinigameLogic : MonoBehaviour
                 p.GetComponentInChildren<PlayerInputHandler>().movementPaused = false;
             }
         }
-
+        GameState.ModifierManager.StartMinigame();
         gameRunning = true;
         onGameStart?.Invoke();
         endCondition.Init();

--- a/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/ModifierSelectionLogic.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/ModifierSelectionLogic.cs
@@ -26,7 +26,7 @@ public class ModifierSelectionLogic : MinigameLogic
 
         
         selector.Init();
-        modifierManager = GameObject.FindGameObjectWithTag("ModifierManager").GetComponent<ModifierManager>();
+        modifierManager = GameState.ModifierManager;
         modifiers = modifierManager.GetRandomModifiers(numberOfModifiers);
         selector.onSelection += OnSelectionFinished;
 

--- a/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/VictoryRoomLogic.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/VictoryRoomLogic.cs
@@ -37,6 +37,7 @@ public class VictoryRoomLogic : MinigameLogic
     public override void CleanUp()
     {
         winningPlayer.GetComponentInChildren<PlayerInputHandler>().crownBox.SetActive(false);
+        GameState.ModifierManager.RemoveAllModifiers();
         GameObject.FindWithTag("ModifierManager").GetComponent<ModifierManager>().RemoveAllModifiers();
         base.CleanUp();
     }

--- a/WhenPushComesToShove/Assets/3-Scripts/Modifiers/ActualModifiers/EqualOpposite.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Modifiers/ActualModifiers/EqualOpposite.cs
@@ -17,9 +17,13 @@ public class EqualOpposite : EventModifier
         HitEvent e = (HitEvent)args.objectArg;
         if(e != null)
         {
+            
             KnockbackData data = e.hitbox.knockbackData;
             KnockbackReciever kbReciever = e.hitbox.owner.GetComponentInChildren<KnockbackReciever>();
-            kbReciever.TakeKnockback(data.strength, -data.GetDirection(e), e.hitbox.owner);
+            if (kbReciever != null && data != null)
+            {
+                kbReciever.TakeKnockback(data.strength, -data.GetDirection(e), e.hitbox.owner);
+            }
         }
     }
 

--- a/WhenPushComesToShove/Assets/9-ScriptableObjects/ModifierLists/DebugLists/BenDebug.asset
+++ b/WhenPushComesToShove/Assets/9-ScriptableObjects/ModifierLists/DebugLists/BenDebug.asset
@@ -13,5 +13,4 @@ MonoBehaviour:
   m_Name: BenDebug
   m_EditorClassIdentifier: 
   modifiers:
-  - modifierPrefab: {fileID: 4615974373273334641, guid: 89de717c69baea6489b03c4896decab7, type: 3}
   - modifierPrefab: {fileID: 8206482788190481985, guid: 4702ba414382c1142955402a205a8e0c, type: 3}

--- a/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638101554938100841
+  lastModified: 638100782721190055
   FileSizes: []
   Exists: 1
 --- !u!114 &-1468950982031199481
@@ -33,7 +33,7 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638101554938170655
+  lastModified: 638100782721200029
   FileSizes:
   - Name: 
     Value: 908
@@ -61,7 +61,7 @@ MonoBehaviour:
   - {fileID: -1808526897751299166}
   StringsBanks:
   - {fileID: -1468950982031199481}
-  cacheTime: 638101554938479825
+  cacheTime: 638100782721409470
   cacheVersion: 131601
 --- !u!114 &2291896933958292084
 MonoBehaviour:
@@ -105,6 +105,6 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Music.bank
   Name: Music
   StudioPath: bank:/Music
-  lastModified: 638101554938479825
+  lastModified: 638100782721409470
   FileSizes: []
   Exists: 1

--- a/WhenPushComesToShove/fmod_editor.log
+++ b/WhenPushComesToShove/fmod_editor.log
@@ -7,7 +7,7 @@
 [LOG] OutputWASAPI::init                       : Output buffer size: 4096 samples, latency: 0.00ms, period: 10.00ms, DSP buffer: 1024 * 4
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 000002773F24E2A8 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 00000177E438D5C8 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
- Cluster bombs not being properly cleaned up on minigame end
- Equal opposite neverending force

**What changes were made:**
- Mingame root is now being set properly on modifiers
- Reference to modifier manager is now on the game state
- Equal and Opposite correctly checks for data before trying to apply a force

**Delete this branch?**
Sure
**Any concerns regarding the changes made in this request?**
Maybe modifier manager should just be a singleton at this point?
