### PR TITLE
Put restraints on the rigidbody to prevent players from moving on start

### DIFF
--- a/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/MinigameLogic.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/MinigameLogic.cs
@@ -42,7 +42,7 @@ public abstract class MinigameLogic : MonoBehaviour
                 foreach (Transform p in GameState.players)
                 {
                     //p.GetComponentInChildren<PlayerMovementScript>().ChangeMoveSpeed(0);
-                    //p.GetComponentInChildren<PlayerInputHandler>().movementPaused = true;
+                    p.GetComponentInChildren<PlayerInputHandler>().movementPaused = true;
                     p.GetComponentInChildren<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezePosition | RigidbodyConstraints2D.FreezeRotation;
                 }
             }
@@ -61,7 +61,7 @@ public abstract class MinigameLogic : MonoBehaviour
             foreach (Transform p in GameState.players)
             {
                 //p.GetComponentInChildren<PlayerMovementScript>().ResetMoveSpeed();
-                //p.GetComponentInChildren<PlayerInputHandler>().movementPaused = false;
+                p.GetComponentInChildren<PlayerInputHandler>().movementPaused = false;
                 p.GetComponentInChildren<Rigidbody2D>().constraints = RigidbodyConstraints2D.None | RigidbodyConstraints2D.FreezeRotation;
             }
         }

--- a/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/MinigameLogic.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/MinigameLogic/MinigameLogic.cs
@@ -42,7 +42,8 @@ public abstract class MinigameLogic : MonoBehaviour
                 foreach (Transform p in GameState.players)
                 {
                     //p.GetComponentInChildren<PlayerMovementScript>().ChangeMoveSpeed(0);
-                    p.GetComponentInChildren<PlayerInputHandler>().movementPaused = true;
+                    //p.GetComponentInChildren<PlayerInputHandler>().movementPaused = true;
+                    p.GetComponentInChildren<Rigidbody2D>().constraints = RigidbodyConstraints2D.FreezePosition | RigidbodyConstraints2D.FreezeRotation;
                 }
             }
         }
@@ -60,7 +61,8 @@ public abstract class MinigameLogic : MonoBehaviour
             foreach (Transform p in GameState.players)
             {
                 //p.GetComponentInChildren<PlayerMovementScript>().ResetMoveSpeed();
-                p.GetComponentInChildren<PlayerInputHandler>().movementPaused = false;
+                //p.GetComponentInChildren<PlayerInputHandler>().movementPaused = false;
+                p.GetComponentInChildren<Rigidbody2D>().constraints = RigidbodyConstraints2D.None | RigidbodyConstraints2D.FreezeRotation;
             }
         }
         GameState.ModifierManager.StartMinigame();

--- a/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638100782721190055
+  lastModified: 638101554938100841
   FileSizes: []
   Exists: 1
 --- !u!114 &-1468950982031199481
@@ -33,7 +33,7 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638100782721200029
+  lastModified: 638101554938170655
   FileSizes:
   - Name: 
     Value: 908
@@ -60,7 +60,7 @@ MonoBehaviour:
   - {fileID: -2994990521748011872}
   StringsBanks:
   - {fileID: -1468950982031199481}
-  cacheTime: 638100782721409470
+  cacheTime: 638101554938479825
   cacheVersion: 131601
 --- !u!114 &334929478233726724
 MonoBehaviour:
@@ -77,7 +77,7 @@ MonoBehaviour:
   Path: ./Assets/FMOD Banks/Desktop/Music.bank
   Name: Music
   StudioPath: bank:/Music
-  lastModified: 638100782721409470
+  lastModified: 638101554938479825
   FileSizes: []
   Exists: 1
 --- !u!114 &6580755882717612183

--- a/WhenPushComesToShove/fmod_editor.log
+++ b/WhenPushComesToShove/fmod_editor.log
@@ -7,7 +7,7 @@
 [LOG] OutputWASAPI::init                       : Output buffer size: 4096 samples, latency: 0.00ms, period: 10.00ms, DSP buffer: 1024 * 4
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 000001D5E3E74178 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 0000027123821248 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
-  On start of games, any force would still be applied even if players shouldn't be moving

**What changes were made:**
- Added constraints to the rigidbody instead of turning off movement

**Delete this branch?**
Yes 

**Any concerns regarding the changes made in this request?**
