### PR TITLE
Fixed the collision bug in tag

### DIFF
--- a/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/Tag.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/Tag.prefab
@@ -5508,7 +5508,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6016210733039343417, guid: 10ec4fdc49392824689fb7116b593a60, type: 3}
       propertyPath: m_fontSize
-      value: 37.6
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 6075843762753115292, guid: 10ec4fdc49392824689fb7116b593a60, type: 3}
       propertyPath: m_Name

--- a/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/Tag.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Levels/Resources/Minigames/Tag.prefab
@@ -2429,7 +2429,7 @@ MonoBehaviour:
   taggedGracePeriodTime: 1
   speedOfTagged: 12
   fractionOfHealthPerSecond: 0.05
-  sizeMultiplierOfTaggedHitBox: 2
+  sizeMultiplierOfTaggedHitBox: 1.5
 --- !u!1 &1867975837
 GameObject:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/PlayerPrefab.prefab
@@ -5231,6 +5231,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   movementPaused: 0
   heavyShoveScript: {fileID: 0}
+  lightShoveScript: {fileID: 0}
   rumble: {fileID: 0}
   performingAction: 0
   sr: {fileID: 0}
@@ -7639,7 +7640,7 @@ PrefabInstance:
       objectReference: {fileID: 6077192093453596328}
     - target: {fileID: 6854435290789191532, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
       propertyPath: m_Color.a
-      value: 0
+      value: 0.6862745
       objectReference: {fileID: 0}
     - target: {fileID: 6854435290789191532, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
       propertyPath: m_Color.b
@@ -7655,7 +7656,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6854435290789191532, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6854435290789191533, guid: 820ac65343dbbf3479089caf2d85396b, type: 3}
       propertyPath: m_RootOrder

--- a/WhenPushComesToShove/Assets/2-Prefabs/Props/Bombs/BlinkBomb_Small.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Props/Bombs/BlinkBomb_Small.prefab
@@ -9767,7 +9767,7 @@ Transform:
   m_GameObject: {fileID: 8027995970586725623}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_LocalScale: {x: 2, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 23016703918805834}
@@ -9963,7 +9963,7 @@ ParticleSystem:
       serializedVersion: 2
       minMaxState: 0
       minColor: {r: 1, g: 1, b: 1, a: 1}
-      maxColor: {r: 0.9607843, g: 0.3137255, b: 0.3137255, a: 0.2509804}
+      maxColor: {r: 0.9607843, g: 0.3137255, b: 0.3137255, a: 0.30588236}
       maxGradient:
         serializedVersion: 2
         key0: {r: 1, g: 1, b: 1, a: 1}
@@ -10407,7 +10407,7 @@ ParticleSystem:
     boxThickness: {x: 0, y: 0, z: 0}
     radiusThickness: 1
     donutRadius: 0.2
-    m_Position: {x: 0, y: -0.073, z: 0}
+    m_Position: {x: 0, y: 0, z: 0}
     m_Rotation: {x: 0, y: 0, z: 0}
     m_Scale: {x: 1, y: 1, z: 1}
     placementMode: 0

--- a/WhenPushComesToShove/Assets/2-Prefabs/Props/Teleporter.prefab
+++ b/WhenPushComesToShove/Assets/2-Prefabs/Props/Teleporter.prefab
@@ -73,6 +73,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   destination: {x: -2.7, y: 2.16}
+  tagsToIgnore:
+  - Shove
+  - GhostShove
 --- !u!212 &3320730265100444911
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/WhenPushComesToShove/Assets/3-Scripts/Props/Teleporter.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Props/Teleporter.cs
@@ -7,14 +7,20 @@ public class Teleporter : MonoBehaviour
     [SerializeField]
     private Vector2 destination;
 
+    public List<string> tagsToIgnore;
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.CompareTag("Player"))
+        foreach (string s in tagsToIgnore)
         {
-            //Ensures the object is teleporting along the z axis
-            collision.transform.position = new Vector3(destination.x, destination.y, collision.transform.position.z);
-        }        
+            if (collision.CompareTag(s))
+            {
+                return;
+            }
+        }
+
+        //Ensures the object is teleporting along the z axis
+        collision.transform.position = new Vector3(destination.x, destination.y, collision.transform.position.z);
     }
 
     private void OnDrawGizmos()

--- a/WhenPushComesToShove/Assets/3-Scripts/Props/Teleporter.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/Props/Teleporter.cs
@@ -10,8 +10,11 @@ public class Teleporter : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        //Ensures the object is teleporting along the z axis
-        collision.transform.position = new Vector3(destination.x, destination.y, collision.transform.position.z);
+        if (collision.CompareTag("Player"))
+        {
+            //Ensures the object is teleporting along the z axis
+            collision.transform.position = new Vector3(destination.x, destination.y, collision.transform.position.z);
+        }        
     }
 
     private void OnDrawGizmos()

--- a/WhenPushComesToShove/Assets/6-VFX/Shove/Final Shove/M_VFX_Shove_WindGust_Pixel.mat
+++ b/WhenPushComesToShove/Assets/6-VFX/Shove/Final Shove/M_VFX_Shove_WindGust_Pixel.mat
@@ -25,7 +25,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 37138adde9d1b0648a004d45dafbc6a0, type: 3}
+        m_Texture: {fileID: 2800000, guid: 0e03c6a4bcf73a24bbb60611e5a83311, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MaskTex:

--- a/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -42,7 +42,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/SFX.bank
   Name: SFX
   StudioPath: bank:/SFX
-  lastModified: 638138046768396823
+  lastModified: 638137856921755265
   FileSizes: []
   Exists: 1
 --- !u!114 &-7759398254355327495
@@ -60,7 +60,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Music.bank
   Name: Music
   StudioPath: bank:/Music
-  lastModified: 638138046768375842
+  lastModified: 638134465092376692
   FileSizes: []
   Exists: 1
 --- !u!114 &-4428693024752816087
@@ -179,7 +179,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638138046768386479
+  lastModified: 638134465092356747
   FileSizes: []
   Exists: 1
 --- !u!114 &11400000
@@ -213,7 +213,7 @@ MonoBehaviour:
   StringsBanks:
   - {fileID: -1468950982031199481}
   - {fileID: 392586915098799111}
-  cacheTime: 638138046768396823
+  cacheTime: 638137856921755265
   cacheVersion: 131601
 --- !u!114 &392586915098799111
 MonoBehaviour:
@@ -230,7 +230,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638138046768375842
+  lastModified: 638137856921735312
   FileSizes:
   - Name: 
     Value: 1134

--- a/WhenPushComesToShove/fmod_editor.log
+++ b/WhenPushComesToShove/fmod_editor.log
@@ -7,7 +7,7 @@
 [LOG] OutputWASAPI::init                       : Output buffer size: 4096 samples, latency: 0.00ms, period: 10.00ms, DSP buffer: 1024 * 4
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 0000018DE07EEBB8 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 000002181598FC68 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
-  Tag would often break the player's shove colliders

**What changes were made:**
- Teleporters now have tags to ignore to ensure they don't teleport the shoving hitboxes
- Scale of the hitboxes was decreased a bit for the tagged player

**Delete this branch?**
Yes

**Any concerns regarding the changes made in this request?**
