### PR TITLE
Got rid of health bars in the lobby once the game is reset

### DIFF
--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
@@ -199,6 +199,11 @@ public class LevelManager : MonoBehaviour
             obj.GetComponentInChildren<Rigidbody2D>().constraints = RigidbodyConstraints2D.None | RigidbodyConstraints2D.FreezeRotation;
         }
 
+        foreach (HealthBar b in GameState.playerHealthBars)
+        {
+            b.gameObject.SetActive(false);
+        }
+
         pathGen.ResetPath();
         //Should remake the path
     }

--- a/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -42,7 +42,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/SFX.bank
   Name: SFX
   StudioPath: bank:/SFX
-  lastModified: 638138046768396823
+  lastModified: 638137856921755265
   FileSizes: []
   Exists: 1
 --- !u!114 &-7759398254355327495
@@ -60,7 +60,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Music.bank
   Name: Music
   StudioPath: bank:/Music
-  lastModified: 638138046768375842
+  lastModified: 638134465092376692
   FileSizes: []
   Exists: 1
 --- !u!114 &-4428693024752816087
@@ -179,7 +179,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638138046768386479
+  lastModified: 638134465092356747
   FileSizes: []
   Exists: 1
 --- !u!114 &11400000
@@ -213,7 +213,7 @@ MonoBehaviour:
   StringsBanks:
   - {fileID: -1468950982031199481}
   - {fileID: 392586915098799111}
-  cacheTime: 638138046768396823
+  cacheTime: 638137856921755265
   cacheVersion: 131601
 --- !u!114 &392586915098799111
 MonoBehaviour:
@@ -230,7 +230,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638138046768375842
+  lastModified: 638137856921735312
   FileSizes:
   - Name: 
     Value: 1134

--- a/WhenPushComesToShove/fmod_editor.log
+++ b/WhenPushComesToShove/fmod_editor.log
@@ -7,7 +7,7 @@
 [LOG] OutputWASAPI::init                       : Output buffer size: 4096 samples, latency: 0.00ms, period: 10.00ms, DSP buffer: 1024 * 4
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 0000018DE07EEBB8 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 00000218159960E8 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.


### PR DESCRIPTION
**What issue(s) is this request trying to address:**
- Health bars were showing up in the lobby after the game was reset

**What changes were made:**
- Health bars are forced to disappear when the game resets to the lobby

**Delete this branch?**
Yes

**Any concerns regarding the changes made in this request?**
