### PR TITLE
Added the build flag to clear the path and set the number of minigame…

### DIFF
--- a/WhenPushComesToShove/Assets/1-Scenes/MainScene.unity
+++ b/WhenPushComesToShove/Assets/1-Scenes/MainScene.unity
@@ -1235,7 +1235,7 @@ MonoBehaviour:
   - {fileID: 8946640581007675338, guid: 07081cb80e7dba84d98a7a860de55d1a, type: 3}
   - {fileID: 8946640581007675338, guid: 2dcdbc6ff6c3fba418021b04850f6443, type: 3}
   levelInitRef: {fileID: 0}
-  minPlayers: 2
+  minPlayers: 4
   maxPlayers: 4
   defaultColor: {fileID: 9100000, guid: 6eb688f05c581a246ac731e968b13fad, type: 2}
   playerColorNames:

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/LevelManager.cs
@@ -114,6 +114,12 @@ public class LevelManager : MonoBehaviour
         {
             pathGen.path.Add(pathGen.allLevels[5].gameObject);
         }
+
+        //Clear path
+        if (Input.GetKeyDown(KeyCode.Alpha7) || Input.GetKeyDown(KeyCode.Keypad7))
+        {
+            pathGen.path.Clear();
+        }
     }
 
     //Will ensure that only the current room on the path will show up

--- a/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/PathGenerator.cs
+++ b/WhenPushComesToShove/Assets/3-Scripts/LevelSystems/PathGenerator.cs
@@ -26,6 +26,15 @@ public class PathGenerator : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+
+        #if UNITY_EDITOR
+
+        #else
+            path.Clear();
+            numOfGames = 4;
+        #endif
+        
+
         GameState.pathGenerator = this;
         numOfRooms = (numOfGames * 2) - 1;
 

--- a/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/WhenPushComesToShove/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -60,7 +60,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Music.bank
   Name: Music
   StudioPath: bank:/Music
-  lastModified: 638139605817049219
+  lastModified: 638140472355860034
   FileSizes: []
   Exists: 1
 --- !u!114 &-4428693024752816087
@@ -179,7 +179,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638139605817034892
+  lastModified: 638140472355850072
   FileSizes: []
   Exists: 1
 --- !u!114 &11400000
@@ -213,7 +213,7 @@ MonoBehaviour:
   StringsBanks:
   - {fileID: -1468950982031199481}
   - {fileID: 392586915098799111}
-  cacheTime: 638139605817049219
+  cacheTime: 638140472355860034
   cacheVersion: 131601
 --- !u!114 &392586915098799111
 MonoBehaviour:
@@ -230,7 +230,7 @@ MonoBehaviour:
   Path: Assets/FMOD Banks/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638139605817044865
+  lastModified: 638140472355860034
   FileSizes:
   - Name: 
     Value: 1134

--- a/WhenPushComesToShove/fmod_editor.log
+++ b/WhenPushComesToShove/fmod_editor.log
@@ -7,7 +7,7 @@
 [LOG] OutputWASAPI::init                       : Output buffer size: 4096 samples, latency: 0.00ms, period: 10.00ms, DSP buffer: 1024 * 4
 [LOG] Thread::initThread                       : Init FMOD stream thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFB, Stack Size: 98304, Semaphore: No, Sleep Time: 10, Looping: Yes.
 [LOG] Thread::initThread                       : Init FMOD mixer thread. Affinity: 0x4000000000000001, Priority: 0xFFFF7FFA, Stack Size: 81920, Semaphore: No, Sleep Time: 0, Looping: Yes.
-[LOG] AsyncManager::init                       : manager 000001FB0D3229B8 isAsync 0 updatePeriod 0.02
+[LOG] AsyncManager::init                       : manager 0000016D226DCAB8 isAsync 0 updatePeriod 0.02
 [LOG] AsyncManager::init                       : done
 [LOG] PlaybackSystem::init                     : 
 [LOG] Thread::initThread                       : Init FMOD Studio sample load thread. Affinity: 0x4000000000000003, Priority: 0xFFFF7FFD, Stack Size: 98304, Semaphore: No, Sleep Time: 1, Looping: No.


### PR DESCRIPTION
…s. Add another hotkey to clear the path

**What issue(s) is this request trying to address:**
-  Kept forgetting to clear the path for builds

**What changes were made:**
- Builds will automatically clear the path and set the number of games to 4
- Added a new hotkey to clear the path

**Delete this branch?**
YEs

**Any concerns regarding the changes made in this request?**
